### PR TITLE
Use temporary directories for output files.

### DIFF
--- a/inst/shinyapps/qrlabelr/app.R
+++ b/inst/shinyapps/qrlabelr/app.R
@@ -3558,14 +3558,18 @@ server <- function(input, output, session) {
     
     cory <- label_pos$y # label y coordinate
     
-    #' Create pdf file to be saved in working directory
-    
-    pdf_filename <<- paste0(input$filename, paste0(input$wdt,'in'), 'x',
-                            paste0(input$hgt,'in'), Sys.time()) # name of pdf file
-    
+
+    # Use common tempdir to write app's outputs
+    # TODO: this funcitonality should moved into a function (DRY)
+    temp_directory <- tempdir()
+ 
+    #' Create pdf file to be saved in temp_directory 
+    pdf_filename <<- file.path(temp_directory,
+                            paste0(input$filename, paste0(input$wdt,'in'), 'x',
+                            paste0(input$hgt,'in'), Sys.time())) # name of pdf file 
+
     pdf_filename <<- paste0(gsub(":","_", pdf_filename), ".pdf")
-    
-    
+
     #' Font size to print text on labels
     fsize <- input$font_size
     


### PR DESCRIPTION
The `EasyQrlabelr` shinny app assumes writing permissions of the start working directory. This does not work in certain shared environments (e.g. JupyerHub), because the start directory might not necessarily be the user's home, it could be the shinny app installation path.

This patch, proposes using a temporary directory for creating the label pdfs `PlotLabel*pdf` and updated field book file `Updated_Fieldbook.csv`. The temporary directory is obtained with the `tempdir()` function. It also tries to centralize to a single variable the name of the updated field book file.

The filenames have basename applied to them, on the download handler, so they present correctly when the user downloads them.