### PR TITLE
Import bslib, except for `show_toast()`

### DIFF
--- a/R/qrlabelr.R
+++ b/R/qrlabelr.R
@@ -3,7 +3,7 @@
 #'
 #' @import argonDash
 #' @import argonR
-#' @import bslib
+#' @rawNamespace import(bslib, except = show_toast)
 #' @import reactable
 #' @import readxl
 #' @import shinyBS


### PR DESCRIPTION
To avoid a warning about `bslib::show_toast()` being overridden by `shinyWidgets::show_toast()`.

This warning appears with the [bslib v0.10.0 release candidate](https://github.com/rstudio/bslib/pull/1272), which we are hoping to submit to CRAN early next week.

```
 Found the following significant warnings:
   Warning: replacing previous import ‘bslib::show_toast’ by ‘shinyWidgets::show_toast’ when loading ‘qrlabelr’
```